### PR TITLE
Improve GitHub action setting

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,12 +4,15 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [8.0, 8.1]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,21 +20,14 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v2
       with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+        php-version: ${{ matrix.php }}
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
-
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
+      run: composer update --prefer-dist --no-progress --no-suggest
 
     - name: Execute PHPUnit
       run: vendor/bin/phpunit


### PR DESCRIPTION
# Changed log

- Improve the GitHub action setting.
- Allow the `master` branch to run the GitHub action when triggering the `git push` event.
- Allow all branches to run the GitHub action when triggering the `git pull` event.
- Using the `shivammathur/setup-php@v2` to setup the `PHP 8.0` and `PHP 8.1` version tests.
- Using the `composer update` command to update the locked dependencies for `PHP 8.1` version test.
- Removing some unused comments.