### PR TITLE
Updates PHP versions in CI workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,26 +8,28 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set PHP version
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer
 
-    - name: Install dependencies
-      run: composer update --prefer-dist --no-progress --no-suggest
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-interaction
 
-    - name: Execute PHPUnit
-      run: vendor/bin/phpunit
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
 
-    - name: Execute PHPStan analyse
-      run: vendor/bin/phpstan
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^8.1"
+    "php": "^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
-    "symfony/var-dumper": "^6.3",
+    "symfony/var-dumper": "^5.4",
     "phpstan/phpstan": "^1.10"
   },
   "autoload": {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -6,10 +6,15 @@ use DeGraciaMathieu\Manager\Exceptions\DriverResolutionException;
 
 abstract class Manager
 {
+    protected Aggregator $aggregator;
+
     public function __construct(
         protected bool $singleton = false,
-        protected Aggregator $aggregator = new Aggregator(),
-    ) {}
+        ?Aggregator $aggregator = null,
+    ) {
+        // php8.0 retro-compatibility
+        $this->aggregator = $aggregator ?? new Aggregator();
+    }
 
     /**
      * Get the default driver name.

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -30,7 +30,7 @@ abstract class Manager
      * @throws \DeGraciaMathieu\Manager\Exceptions\DriverOverwrittenException
      * @throws \DeGraciaMathieu\Manager\Exceptions\DriverResolutionException
      */
-    public function driver(string $name = null): mixed
+    public function driver(?string $name = null): mixed
     {
         $name = $name ?: $this->getDefaultDriver();
 


### PR DESCRIPTION
Updates the PHP versions used in the CI workflow to include PHP 8.0, 8.3, 8.4 and 8.5 for broader test coverage.

Also updates the checkout action to v4 and provides more descriptive names for each step.